### PR TITLE
Fix broken compilation because of newer zbar_version prototype.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,11 @@ impl From<i32> for ZBarErrorType {
     fn from(error: i32) -> Self { ZBarErrorType::Complex(unsafe { mem::transmute(error) } ) }
 }
 
-pub fn version() -> (u32, u32) {
+pub fn version() -> (u32, u32, u32) {
     unsafe {
-        let mut version = (0, 0);
-        ffi::zbar_version(&mut version.0 as *mut u32, &mut version.1 as *mut u32);
+        let mut version = (0, 0, 0);
+        ffi::zbar_version(
+            &mut version.0 as *mut u32, &mut version.1 as *mut u32, &mut version.2 as *mut u32);
         version
     }
 }


### PR DESCRIPTION
Hi,
I've been trying to use zbars as a dependency and I was surprised to see it does not compile.

Newer version of zbar exposes a `zbar_version` taking not two but three parameters. Thus zbars (either 0.2.0 or master) does not compile anymore against newer version of zbar. 

This PR fixes that.